### PR TITLE
Add Police Notification support, Black Money Support and fixed police typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Support Discord
 dreamzz#2871
+
+## Notification and Black Money Support
 !0pax#7662
 
 ROB CASH REGISTER [ESX]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To rob you need to open the cash register first with a crowbar (WEAPON_CROWBAR) 
 - Easy to modify
 - To change the amount of money you want, just change it on server.lua
 - Optimized script
+- Add your own police notification message in server.lua where it's commented out. 
 
 ## Using esx_robcashregister
 - Copy the "esx_robcashregister" into your scripts folder

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Support Discord
 dreamzz#2871
+!0pax#7662
 
 ROB CASH REGISTER [ESX]
 

--- a/client.lua
+++ b/client.lua
@@ -15,6 +15,7 @@ local PlayerData                = {}
 local incollect                 = false
 local onplace                 = false
 local coords            = {}
+local blipTime = 25 --in seconds
 
 RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(xPlayer)
@@ -70,6 +71,8 @@ AddEventHandler('esx_robcashregister:startstealcash', function()
         OpenCashregister()
         Citizen.Wait(9999)
         exports['mythic_notify']:DoHudText('inform', 'Cash register opened')
+        TriggerServerEvent('robberyNotif', street1)
+        TriggerServerEvent('robberyOnGoing', plyPos.x, plyPos.y, plyPos.z)
         TriggerServerEvent('InteractSound_SV:PlayWithinDistance', 30.0, 'alarm', 0.3) -- IF YOU WANT TO USE ALARM SOUND CHANGE THE SOUND OF "ALARM" TO YOUR FILE NAME
       else
         exports['mythic_notify']:DoHudText('error', 'No cops')
@@ -128,3 +131,23 @@ function startRobbing ()
   end)
 end
 
+RegisterNetEvent('robberyBlip')
+AddEventHandler('robberyBlip', function(tx, ty, tz)
+	if PlayerData.job.name == 'police' then
+		local transT = 250
+		local Blip = AddBlipForCoord(tx, ty, tz)
+		SetBlipSprite(Blip,  10)
+		SetBlipColour(Blip,  1)
+		SetBlipAlpha(Blip,  transT)
+		SetBlipAsShortRange(Blip,  false)
+		while transT ~= 0 do
+			Wait(blipTime * 4)
+			transT = transT - 1
+			SetBlipAlpha(Blip,  transT)
+			if transT == 0 then
+				SetBlipSprite(Blip,  2)
+				return
+			end
+		end
+	end
+end)

--- a/config.lua
+++ b/config.lua
@@ -10,3 +10,6 @@ Config.Zone = {
 	shop7 = {x = -706.06, y = -913.59, z = 19.22},
 	shop8 = {x = -706.07, y = -915.4, z = 19.22}
 }
+
+Config.UseNormalMoney = false
+Config.UseBlackMoney = true

--- a/server.lua
+++ b/server.lua
@@ -41,11 +41,19 @@ AddEventHandler('esx_robcashregister:givemoney', function()
 	local xPlayer = ESX.GetPlayerFromId(source)
 	local money = math.random(1500, 2500)
 	if isrobbing[source] then
-		xPlayer.addMoney(money)
-		TriggerClientEvent('mythic_notify:client:SendAlert', source , { type = 'inform', text = 'You steal  $' ..money })
-		isrobbing[source] = nil
-	else
-		print("Cheater: " .. GetPlayerName(source))
+		if Config.UseNormalMoney = true then
+			xPlayer.addMoney(money)
+			TriggerClientEvent('mythic_notify:client:SendAlert', source , { type = 'inform', text = 'You steal  $' ..money })
+			isrobbing[source] = nil
+		else
+			if Config.UseBlackMoney = true then
+				xPlayer.addAccountMoney('black_money', money)
+				TriggerClientEvent('mythic_notify:client:SendAlert', source , { type = 'inform', text = 'You steal  $' ..money })
+				isrobbing[source] = nil
+			else
+				print("Cheater: " .. GetPlayerName(source))
+			end
+		end
 	end
 end)
 

--- a/server.lua
+++ b/server.lua
@@ -41,17 +41,23 @@ AddEventHandler('esx_robcashregister:givemoney', function()
 	local xPlayer = ESX.GetPlayerFromId(source)
 	local money = math.random(1500, 2500)
 	if isrobbing[source] then
-		if Config.UseNormalMoney = true then
+		if Config.UseBlackMoney = false and Config.UseNormalMoney = true then
 			xPlayer.addMoney(money)
 			TriggerClientEvent('mythic_notify:client:SendAlert', source , { type = 'inform', text = 'You steal  $' ..money })
 			isrobbing[source] = nil
 		else
-			if Config.UseBlackMoney = true then
+			if Config.UseNormalMoney = false and Config.UseBlackMoney = true then
 				xPlayer.addAccountMoney('black_money', money)
 				TriggerClientEvent('mythic_notify:client:SendAlert', source , { type = 'inform', text = 'You steal  $' ..money })
 				isrobbing[source] = nil
 			else
-				print("Cheater: " .. GetPlayerName(source))
+				if Config.UseNormalMoney = false and Config.UseBlackMoney = false then
+					xPlayer.addAccountMoney('black_money', money)
+					TriggerClientEvent('mythic_notify:client:SendAlert', source , { type = 'inform', text = 'You steal  $' ..money })
+					isrobbing[source] = nil
+				else
+					print("Cheater: " .. GetPlayerName(source))
+				end
 			end
 		end
 	end

--- a/server.lua
+++ b/server.lua
@@ -64,3 +64,29 @@ AddEventHandler("esx_robcashregister:cancelled", function()
         isrobbing[source] = nil
     end
 end)
+
+RegisterServerEvent('robberyNotif')
+AddEventHandler('robberyNotif', function()
+end)
+
+RegisterServerEvent('robberyNotif')
+AddEventHandler('robberyNotif', function(street1, street2, sex)
+	local _source = source
+	local xPlayers = ESX.GetPlayers()
+	for i=1, #xPlayers, 1 do
+		local xPlayer = ESX.GetPlayerFromId(xPlayers[i])
+		if xPlayer.job.name == 'police' then
+			-- ADD NOTIFICATION MESSAGE HERE
+		end
+    end
+end)
+
+RegisterServerEvent('robberyPosition')
+AddEventHandler('robberyPosition', function(gx, gy, gz)
+	TriggerClientEvent('robberyBlip', -1, gx, gy, gz)
+end)
+
+RegisterServerEvent('robberyOnGoing')
+AddEventHandler('robberyOnGoing', function(gx, gy, gz)
+	TriggerClientEvent('robberyBlip', -1, gx, gy, gz)
+end)

--- a/server.lua
+++ b/server.lua
@@ -90,7 +90,7 @@ AddEventHandler('robberyNotif', function(street1, street2, sex)
 	for i=1, #xPlayers, 1 do
 		local xPlayer = ESX.GetPlayerFromId(xPlayers[i])
 		if xPlayer.job.name == 'police' then
-			-- ADD NOTIFICATION MESSAGE HERE
+			TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'inform', text = 'A robbery was started at ' .. street1 .. '!', style = { ['background-color'] = '###', ['color'] = '#FFFFFF' } })
 		end
     end
 end)

--- a/server.lua
+++ b/server.lua
@@ -12,7 +12,7 @@ ESX.RegisterServerCallback('esx_robcashregister:countpolice', function(source, c
     for i=1, #xPlayers, 1 do
         local Player = ESX.GetPlayerFromId(xPlayers[i])
         if Player.job.name == 'police' then
-           pcountPolice = pcountPolice + 3
+           pcountPolice = pcountPolice + 1
         end
     end
 


### PR DESCRIPTION
Added police notifications when robbery is started, it includes adding a blip for all on duty officers. Also added support for black money, can be changed back to clean money in the config. Also fixed typo where it said 1 officer would be 3, so 1 = 3, changed it back to 1 = 1. I haven't fully tested it but it should work as intended. I also added support so if both statements in the config = false then it just uses black money until anything is changed in the config. I hope you like it!